### PR TITLE
Add linter package - base

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -1,0 +1,12 @@
+name: golangci-lint
+on: [push, pull_request]
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2.3.0
+        with:
+          version: v1.40.1

--- a/.gitignore
+++ b/.gitignore
@@ -11,5 +11,8 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
+# JetBrains
+.idea/
+
 # Dependency directories (remove the comment below to include it)
 # vendor/

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,69 @@
+linters-settings:
+  goimports:
+    local-prefixes: github.com/kudelskisecurity/crystals-go
+
+linters:
+  disable-all: true
+  # pending (either enable and handle, or deliberately drop):
+  #  - deadcode
+  #  - errcheck
+  #  - gocritic
+  #  - godot
+  #  - godot
+  #  - gofmt
+  #  - goimports
+  #  - gosec
+  #  - ifshort
+  #  - misspell
+  #  - paralleltest
+  #  - predeclared
+  #  - revive
+  #  - stylecheck
+  #  - testpackage
+  #  - thelper
+  #  - unconvert
+  #  - unused
+  #  - wastedassign
+  enable:
+    - asciicheck
+    - depguard
+    - dogsled
+    - dupl
+    - durationcheck
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - forcetypeassert
+    - gci
+    - gochecknoinits
+    - goconst
+    - gocyclo
+    - godox
+    - goerr113
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosimple
+    - govet
+    - importas
+    - ineffassign
+    - makezero
+    - nakedret
+    - nestif
+    - nilerr
+    - nolintlint
+    - prealloc
+    - rowserrcheck
+    - staticcheck
+    - structcheck
+    - tagliatelle
+    - tparallel
+    - typecheck
+    - unparam
+    - varcheck
+    - wrapcheck
+
+issues:
+  exclude-use-default: false # disable filtering of defaults for better zero-issue policy
+  max-per-linter: 0 # disable limit; report all issues of a linter
+  max-same-issues: 0 # disable limit; report all issues of the same issue

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,9 +9,6 @@ linters:
   #  - errcheck
   #  - gocritic
   #  - godot
-  #  - godot
-  #  - gofmt
-  #  - goimports
   #  - gosec
   #  - ifshort
   #  - misspell
@@ -40,6 +37,8 @@ linters:
     - gocyclo
     - godox
     - goerr113
+    - gofmt
+    - goimports
     - gomoddirectives
     - gomodguard
     - goprintffuncname

--- a/crystals-dilithium/benchmark_test.go
+++ b/crystals-dilithium/benchmark_test.go
@@ -33,17 +33,17 @@ func BenchmarkECDSAVerify(b *testing.B) {
 	}
 }
 
-func BenchmarkKeyGen2(b *testing.B)        { benchmarkKeyGen(b, NewDilithium2(false)) }
-func BenchmarkSign2(b *testing.B)          { benchmarkSign(b, NewDilithium2(false)) }
-func BenchmarkVerify2(b *testing.B)        { benchmarkVerify(b, NewDilithium2(false)) }
+func BenchmarkKeyGen2(b *testing.B) { benchmarkKeyGen(b, NewDilithium2(false)) }
+func BenchmarkSign2(b *testing.B)   { benchmarkSign(b, NewDilithium2(false)) }
+func BenchmarkVerify2(b *testing.B) { benchmarkVerify(b, NewDilithium2(false)) }
 
-func BenchmarkKeyGen3(b *testing.B)        { benchmarkKeyGen(b, NewDilithium3(false)) }
-func BenchmarkSign3(b *testing.B)          { benchmarkSign(b, NewDilithium3(false)) }
-func BenchmarkVerify3(b *testing.B)        { benchmarkVerify(b, NewDilithium3(false)) }
+func BenchmarkKeyGen3(b *testing.B) { benchmarkKeyGen(b, NewDilithium3(false)) }
+func BenchmarkSign3(b *testing.B)   { benchmarkSign(b, NewDilithium3(false)) }
+func BenchmarkVerify3(b *testing.B) { benchmarkVerify(b, NewDilithium3(false)) }
 
-func BenchmarkKeyGen5(b *testing.B)        { benchmarkKeyGen(b, NewDilithium5(false)) }
-func BenchmarkSign5(b *testing.B)          { benchmarkSign(b, NewDilithium5(false)) }
-func BenchmarkVerify5(b *testing.B)        { benchmarkVerify(b, NewDilithium5(false)) }
+func BenchmarkKeyGen5(b *testing.B) { benchmarkKeyGen(b, NewDilithium5(false)) }
+func BenchmarkSign5(b *testing.B)   { benchmarkSign(b, NewDilithium5(false)) }
+func BenchmarkVerify5(b *testing.B) { benchmarkVerify(b, NewDilithium5(false)) }
 
 func benchmarkKeyGen(b *testing.B, d *Dilithium) {
 	var seed [32]byte


### PR DESCRIPTION
This PR adds the linter package `golangci-lint` with some initial linters enabled and adapted for. Also included is a GitHub action to run them automatically.
Motivation for this is to allow adherence to established standards for a critical library.

This PR is a smaller, first step than originally #1 was planned.
