### PR TITLE
fix dilithium benchmark test

### DIFF
--- a/crystals-dilithium/benchmark_test.go
+++ b/crystals-dilithium/benchmark_test.go
@@ -33,17 +33,17 @@ func BenchmarkECDSAVerify(b *testing.B) {
 	}
 }
 
-func BenchmarkKeyGen2(b *testing.B)        { benchmarkKeyGen(b, NewDilithium2(false)) }
-func BenchmarkSign2(b *testing.B)          { benchmarkSign(b, NewDilithium2(false)) }
-func BenchmarkVerify2(b *testing.B)        { benchmarkVerify(b, NewDilithium2(false)) }
+func BenchmarkKeyGen2(b *testing.B) { benchmarkKeyGen(b, NewDilithium2(false)) }
+func BenchmarkSign2(b *testing.B)   { benchmarkSign(b, NewDilithium2(false)) }
+func BenchmarkVerify2(b *testing.B) { benchmarkVerify(b, NewDilithium2(false)) }
 
-func BenchmarkKeyGen3(b *testing.B)        { benchmarkKeyGen(b, NewDilithium3(false)) }
-func BenchmarkSign3(b *testing.B)          { benchmarkSign(b, NewDilithium3(false)) }
-func BenchmarkVerify3(b *testing.B)        { benchmarkVerify(b, NewDilithium3(false)) }
+func BenchmarkKeyGen3(b *testing.B) { benchmarkKeyGen(b, NewDilithium3(false)) }
+func BenchmarkSign3(b *testing.B)   { benchmarkSign(b, NewDilithium3(false)) }
+func BenchmarkVerify3(b *testing.B) { benchmarkVerify(b, NewDilithium3(false)) }
 
-func BenchmarkKeyGen5(b *testing.B)        { benchmarkKeyGen(b, NewDilithium5(false)) }
-func BenchmarkSign5(b *testing.B)          { benchmarkSign(b, NewDilithium5(false)) }
-func BenchmarkVerify5(b *testing.B)        { benchmarkVerify(b, NewDilithium5(false)) }
+func BenchmarkKeyGen5(b *testing.B) { benchmarkKeyGen(b, NewDilithium5(false)) }
+func BenchmarkSign5(b *testing.B)   { benchmarkSign(b, NewDilithium5(false)) }
+func BenchmarkVerify5(b *testing.B) { benchmarkVerify(b, NewDilithium5(false)) }
 
 func benchmarkKeyGen(b *testing.B, d *Dilithium) {
 	var seed [32]byte
@@ -57,7 +57,7 @@ func benchmarkSign(b *testing.B, d *Dilithium) {
 	var seed [32]byte
 	_, sk := d.KeyGen(seed[:])
 	for n := 0; n < b.N; n++ {
-		d.Sign(msg[:], sk)
+		d.Sign(sk, msg[:])
 	}
 }
 
@@ -65,8 +65,8 @@ func benchmarkVerify(b *testing.B, d *Dilithium) {
 	var msg [59]byte
 	var seed [32]byte
 	pk, sk := d.KeyGen(seed[:])
-	sig := d.Sign(msg[:], sk)
+	sig := d.Sign(sk, msg[:])
 	for n := 0; n < b.N; n++ {
-		d.Verify(msg[:], sig, pk)
+		d.Verify(pk, msg[:], sig)
 	}
 }


### PR DESCRIPTION
This PR is to fix some bugs found in crystals-dilithium/benchmark_test.go.
Wrong parameters for DilithiumX's sign/verify function.